### PR TITLE
Fix Blocking issue -- flush method when there is only one failure

### DIFF
--- a/packages/soft-assert/src/soft-assert.ts
+++ b/packages/soft-assert/src/soft-assert.ts
@@ -126,13 +126,15 @@ export class SoftAssert {
     }
 
     flush() {
-        if(this.captured.length > 1) {
-            const message = this.captured.map(formatAssertionError).join("\n");
+        if (this.captured.length > 1) {
+            let message = `Total failures are: ${this.captured.length}\n\n${this.captured.map(formatAssertionError).join("\n\n")}`;
             this.captured = [];
-            throw new AssertionError({message});
-            
-        } else if(this.captured.length === 1) {
-            throw this.captured[0];
+            throw new AssertionError({ message });
+        }
+        else if (this.captured.length === 1) {
+            const message = this.captured[0];
+            this.captured = [];
+            throw message;
         }
     }
 


### PR DESCRIPTION
### Issue: 
When there is only 1 failure, the next scenarios also fails for the same reason, because the `captured[]` array does not get empty for 1 failure in the `flush` metho

### Solution: 
It should empty the `captured[]` array when there is only one failure